### PR TITLE
ASINT-2057: Add default extension to file names in TeamCity interface

### DIFF
--- a/ptai-teamcity-plugin/build.gradle
+++ b/ptai-teamcity-plugin/build.gradle
@@ -1,3 +1,13 @@
+buildscript {
+    repositories {
+        maven { url mavenCentralRepoUrl }
+        maven { url jenkinsReleasesRepoUrl }
+    }
+    dependencies {
+        classpath("org.jvnet.localizer:maven-localizer-plugin:${localizerVersion}")
+    }
+}
+
 plugins {
     // https://github.com/rodm/gradle-teamcity-plugin
     id "com.github.rodm.teamcity-common" version "1.5" apply false
@@ -12,5 +22,6 @@ subprojects {
     dependencies {
         // https://mvnrepository.com/artifact/org.slf4j/slf4j-log4j12
         implementation group: 'org.slf4j', name: 'slf4j-log4j12', version: '1.7.36'
+        implementation "org.jvnet.localizer:localizer:${localizerVersion}"
     }
 }

--- a/ptai-teamcity-plugin/build.gradle
+++ b/ptai-teamcity-plugin/build.gradle
@@ -1,13 +1,3 @@
-buildscript {
-    repositories {
-        maven { url mavenCentralRepoUrl }
-        maven { url jenkinsReleasesRepoUrl }
-    }
-    dependencies {
-        classpath("org.jvnet.localizer:maven-localizer-plugin:${localizerVersion}")
-    }
-}
-
 plugins {
     // https://github.com/rodm/gradle-teamcity-plugin
     id "com.github.rodm.teamcity-common" version "1.5" apply false
@@ -22,6 +12,5 @@ subprojects {
     dependencies {
         // https://mvnrepository.com/artifact/org.slf4j/slf4j-log4j12
         implementation group: 'org.slf4j', name: 'slf4j-log4j12', version: '1.7.36'
-        implementation "org.jvnet.localizer:localizer:${localizerVersion}"
     }
 }

--- a/ptai-teamcity-plugin/ptai-teamcity-plugin-common/src/main/java/com/ptsecurity/appsec/ai/ee/utils/ci/integration/plugin/teamcity/Defaults.java
+++ b/ptai-teamcity-plugin/ptai-teamcity-plugin-common/src/main/java/com/ptsecurity/appsec/ai/ee/utils/ci/integration/plugin/teamcity/Defaults.java
@@ -144,7 +144,7 @@ public class Defaults {
     /**
      * See {@link Params#REPORTING_REPORT_FILE}
      */
-    public static final String REPORTING_REPORT_FILE = EMPTY;
+    public static final String REPORTING_REPORT_FILE = "report.html";
 
     /**
      * See {@link Params#REPORTING_REPORT_TEMPLATE}
@@ -159,7 +159,7 @@ public class Defaults {
     /**
      * See {@link Params#REPORTING_RAWDATA_FILE}
      */
-    public static final String REPORTING_RAWDATA_FILE = EMPTY;
+    public static final String REPORTING_RAWDATA_FILE = "report.json";
 
     /**
      * See {@link Params#REPORTING_RAWDATA_FILTER}
@@ -169,7 +169,7 @@ public class Defaults {
     /**
      * See {@link Params#REPORTING_SARIF_FILE}
      */
-    public static final String REPORTING_SARIF_FILE = EMPTY;
+    public static final String REPORTING_SARIF_FILE = "sarif_report.json";
 
     /**
      * See {@link Params#REPORTING_SARIF_FILTER}
@@ -179,7 +179,7 @@ public class Defaults {
     /**
      * See {@link Params#REPORTING_SONARGIIF_FILE}
      */
-    public static final String REPORTING_SONARGIIF_FILE = EMPTY;
+    public static final String REPORTING_SONARGIIF_FILE = "sonar_giif_report.json";
 
     /**
      * See {@link Params#REPORTING_SONARGIIF_FILTER}

--- a/ptai-teamcity-plugin/ptai-teamcity-plugin-common/src/main/java/com/ptsecurity/appsec/ai/ee/utils/ci/integration/plugin/teamcity/ReportsHelper.java
+++ b/ptai-teamcity-plugin/ptai-teamcity-plugin-common/src/main/java/com/ptsecurity/appsec/ai/ee/utils/ci/integration/plugin/teamcity/ReportsHelper.java
@@ -5,7 +5,6 @@ import com.ptsecurity.misc.tools.exceptions.GenericException;
 import com.ptsecurity.appsec.ai.ee.utils.ci.integration.utils.ReportUtils;
 import lombok.NonNull;
 import org.apache.commons.lang3.StringUtils;
-import org.jvnet.localizer.LocaleProvider;
 
 import java.util.Locale;
 import java.util.Map;
@@ -58,7 +57,9 @@ public class ReportsHelper {
     }
 
     private static com.ptsecurity.appsec.ai.ee.scan.reports.Reports.Locale getDefaultLocale() {
-        Locale locale = LocaleProvider.getLocale();
+        String country = System.getProperty("user.country");
+        String language = System.getProperty("user.language");
+        Locale locale = new Locale(language, country);
         if (locale.getLanguage().equalsIgnoreCase(Reports.Locale.RU.name()))
             return Reports.Locale.RU;
         else

--- a/ptai-teamcity-plugin/ptai-teamcity-plugin-common/src/main/java/com/ptsecurity/appsec/ai/ee/utils/ci/integration/plugin/teamcity/ReportsHelper.java
+++ b/ptai-teamcity-plugin/ptai-teamcity-plugin-common/src/main/java/com/ptsecurity/appsec/ai/ee/utils/ci/integration/plugin/teamcity/ReportsHelper.java
@@ -5,7 +5,9 @@ import com.ptsecurity.misc.tools.exceptions.GenericException;
 import com.ptsecurity.appsec.ai.ee.utils.ci.integration.utils.ReportUtils;
 import lombok.NonNull;
 import org.apache.commons.lang3.StringUtils;
+import org.jvnet.localizer.LocaleProvider;
 
+import java.util.Locale;
 import java.util.Map;
 
 import static com.ptsecurity.appsec.ai.ee.utils.ci.integration.plugin.teamcity.Constants.TRUE;
@@ -47,5 +49,19 @@ public class ReportsHelper {
             res.append(ReportUtils.validateJsonReports(data.get(REPORTING_JSON_SETTINGS)));
 
         return res;
+    }
+
+    public static String getDefaultTemplate() {
+        return Reports.Locale.RU == getDefaultLocale()
+                ? "Отчет по результатам сканирования"
+                : "Scan results report";
+    }
+
+    private static com.ptsecurity.appsec.ai.ee.scan.reports.Reports.Locale getDefaultLocale() {
+        Locale locale = LocaleProvider.getLocale();
+        if (locale.getLanguage().equalsIgnoreCase(Reports.Locale.RU.name()))
+            return Reports.Locale.RU;
+        else
+            return Reports.Locale.EN;
     }
 }

--- a/ptai-teamcity-plugin/ptai-teamcity-plugin-common/src/main/java/com/ptsecurity/appsec/ai/ee/utils/ci/integration/plugin/teamcity/ReportsHelper.java
+++ b/ptai-teamcity-plugin/ptai-teamcity-plugin-common/src/main/java/com/ptsecurity/appsec/ai/ee/utils/ci/integration/plugin/teamcity/ReportsHelper.java
@@ -56,7 +56,7 @@ public class ReportsHelper {
                 : "Scan results report";
     }
 
-    private static com.ptsecurity.appsec.ai.ee.scan.reports.Reports.Locale getDefaultLocale() {
+    private static Reports.Locale getDefaultLocale() {
         String country = System.getProperty("user.country");
         String language = System.getProperty("user.language");
         Locale locale = new Locale(language, country);

--- a/ptai-teamcity-plugin/ptai-teamcity-plugin-server/src/main/resources/buildServerResources/constants.jsp
+++ b/ptai-teamcity-plugin/ptai-teamcity-plugin-server/src/main/resources/buildServerResources/constants.jsp
@@ -2,6 +2,8 @@
 <%@ page import="com.ptsecurity.appsec.ai.ee.utils.ci.integration.plugin.teamcity.Hints" %>
 <%@ page import="com.ptsecurity.appsec.ai.ee.utils.ci.integration.plugin.teamcity.Labels" %>
 <%@ page import="com.ptsecurity.appsec.ai.ee.utils.ci.integration.plugin.teamcity.Params" %>
+<%@ page import="com.ptsecurity.appsec.ai.ee.utils.ci.integration.plugin.teamcity.Defaults" %>
+<%@ page import="com.ptsecurity.appsec.ai.ee.utils.ci.integration.plugin.teamcity.ReportsHelper" %>
 
 <c:set var="SERVER_SETTINGS_GLOBAL_URL" value="<%=Params.URL%>"/>
 <c:set var="LABEL_SERVER_SETTINGS_GLOBAL_URL" value="<%=Labels.URL%>"/>
@@ -99,10 +101,12 @@
 <c:set var="REPORTING_REPORT_FILE" value="<%=Params.REPORTING_REPORT_FILE%>"/>
 <c:set var="LABEL_REPORTING_REPORT_FILE" value="<%=Labels.REPORTING_REPORT_FILE%>"/>
 <c:set var="HINT_REPORTING_REPORT_FILE" value="<%=Hints.REPORTING_REPORT_FILE%>"/>
+<c:set var="DEFAULT_REPORTING_REPORT_FILE" value="<%=Defaults.REPORTING_REPORT_FILE%>"/>
 
 <c:set var="REPORTING_REPORT_TEMPLATE" value="<%=Params.REPORTING_REPORT_TEMPLATE%>"/>
 <c:set var="LABEL_REPORTING_REPORT_TEMPLATE" value="<%=Labels.REPORTING_REPORT_TEMPLATE%>"/>
 <c:set var="HINT_REPORTING_REPORT_TEMPLATE" value="<%=Hints.REPORTING_REPORT_TEMPLATE%>"/>
+<c:set var="DEFAULT_REPORTING_REPORT_TEMPLATE" value="<%=ReportsHelper.getDefaultTemplate()%>"/>
 
 <%-- Valid locale values and labels --%>
 <c:set var="REPORTING_LOCALE_ENGLISH" value="<%=Constants.REPORTING_LOCALE_ENGLISH%>"/>
@@ -122,6 +126,7 @@
 <c:set var="REPORTING_RAWDATA_FILE" value="<%=Params.REPORTING_RAWDATA_FILE%>"/>
 <c:set var="LABEL_REPORTING_RAWDATA_FILE" value="<%=Labels.REPORTING_RAWDATA_FILE%>"/>
 <c:set var="HINT_REPORTING_RAWDATA_FILE" value="<%=Hints.REPORTING_RAWDATA_FILE%>"/>
+<c:set var="DEFAULT_REPORTING_RAWDATA_FILE" value="<%=Defaults.REPORTING_RAWDATA_FILE%>"/>
 
 <c:set var="REPORTING_RAWDATA_FILTER" value="<%=Params.REPORTING_RAWDATA_FILTER%>"/>
 <c:set var="LABEL_REPORTING_RAWDATA_FILTER" value="<%=Labels.REPORTING_RAWDATA_FILTER%>"/>
@@ -135,6 +140,7 @@
 <c:set var="REPORTING_SARIF_FILE" value="<%=Params.REPORTING_SARIF_FILE%>"/>
 <c:set var="LABEL_REPORTING_SARIF_FILE" value="<%=Labels.REPORTING_SARIF_FILE%>"/>
 <c:set var="HINT_REPORTING_SARIF_FILE" value="<%=Hints.REPORTING_SARIF_FILE%>"/>
+<c:set var="DEFAULT_REPORTING_SARIF_FILE" value="<%=Defaults.REPORTING_SARIF_FILE%>"/>
 
 <c:set var="REPORTING_SARIF_FILTER" value="<%=Params.REPORTING_SARIF_FILTER%>"/>
 <c:set var="LABEL_REPORTING_SARIF_FILTER" value="<%=Labels.REPORTING_SARIF_FILTER%>"/>
@@ -148,6 +154,7 @@
 <c:set var="REPORTING_SONARGIIF_FILE" value="<%=Params.REPORTING_SONARGIIF_FILE%>"/>
 <c:set var="LABEL_REPORTING_SONARGIIF_FILE" value="<%=Labels.REPORTING_SONARGIIF_FILE%>"/>
 <c:set var="HINT_REPORTING_SONARGIIF_FILE" value="<%=Hints.REPORTING_SONARGIIF_FILE%>"/>
+<c:set var="DEFAULT_REPORTING_SONARGIIF_FILE" value="<%=Defaults.REPORTING_SONARGIIF_FILE%>"/>
 
 <c:set var="REPORTING_SONARGIIF_FILTER" value="<%=Params.REPORTING_SONARGIIF_FILTER%>"/>
 <c:set var="LABEL_REPORTING_SONARGIIF_FILTER" value="<%=Labels.REPORTING_SONARGIIF_FILTER%>"/>
@@ -198,3 +205,4 @@
 <c:set var="ADMIN_CONTROLLER_PATH" value="<%=Constants.ADMIN_CONTROLLER_PATH%>"/>
 <c:set var="TEST_CONTROLLER_PATH" value="<%=Constants.AST_CONTROLLER_PATH%>"/>
 
+<c:set var="FALSE" value="<%=Constants.FALSE%>"/>

--- a/ptai-teamcity-plugin/ptai-teamcity-plugin-server/src/main/resources/buildServerResources/editRunParams.jsp
+++ b/ptai-teamcity-plugin/ptai-teamcity-plugin-server/src/main/resources/buildServerResources/editRunParams.jsp
@@ -378,7 +378,14 @@
             <label for="${REPORTING_REPORT_FILE}">${LABEL_REPORTING_REPORT_FILE}<l:star/></label>
         </th>
         <td class="noBorder dense">
-            <props:textProperty name="${REPORTING_REPORT_FILE}" className="longField"/>
+            <props:textProperty
+                    name="${REPORTING_REPORT_FILE}"
+                    value="${
+                        propertiesBean.properties[REPORTING_REPORT] == FALSE
+                        ? DEFAULT_REPORTING_REPORT_FILE
+                        : propertiesBean.properties[REPORTING_REPORT_FILE]
+                    }"
+                    className="longField"/>
             <span class="smallNote">${HINT_REPORTING_REPORT_FILE}</span>
         </td>
     </tr>
@@ -387,7 +394,14 @@
             <label for="${REPORTING_REPORT_TEMPLATE}">${LABEL_REPORTING_REPORT_TEMPLATE}<l:star/></label>
         </th>
         <td class="noBorder dense">
-            <props:textProperty name="${REPORTING_REPORT_TEMPLATE}" className="longField"/>
+            <props:textProperty
+                    name="${REPORTING_REPORT_TEMPLATE}"
+                    value="${
+                        propertiesBean.properties[REPORTING_REPORT] == FALSE
+                        ? DEFAULT_REPORTING_REPORT_TEMPLATE
+                        : propertiesBean.properties[REPORTING_REPORT_TEMPLATE]
+                    }"
+                    className="longField"/>
             <span class="smallNote">${HINT_REPORTING_REPORT_TEMPLATE}</span>
         </td>
     </tr>
@@ -422,7 +436,14 @@
             <label for="${REPORTING_RAWDATA_FILE}">${LABEL_REPORTING_RAWDATA_FILE}<l:star/></label>
         </th>
         <td class="noBorder dense">
-            <props:textProperty name="${REPORTING_RAWDATA_FILE}" className="longField"/>
+            <props:textProperty
+                    name="${REPORTING_RAWDATA_FILE}"
+                    value="${
+                        propertiesBean.properties[REPORTING_RAWDATA] == FALSE
+                        ? DEFAULT_REPORTING_RAWDATA_FILE
+                        : propertiesBean.properties[REPORTING_RAWDATA_FILE]
+                    }"
+                    className="longField"/>
             <span class="smallNote">${HINT_REPORTING_RAWDATA_FILE}</span>
         </td>
     </tr>
@@ -457,7 +478,14 @@
             <label for="${REPORTING_SARIF_FILE}">${LABEL_REPORTING_SARIF_FILE}<l:star/></label>
         </th>
         <td class="noBorder dense">
-            <props:textProperty name="${REPORTING_SARIF_FILE}" className="longField"/>
+            <props:textProperty
+                    name="${REPORTING_SARIF_FILE}"
+                    value="${
+                        propertiesBean.properties[REPORTING_SARIF] == FALSE
+                        ? DEFAULT_REPORTING_SARIF_FILE
+                        : propertiesBean.properties[REPORTING_SARIF_FILE]
+                    }"
+                    className="longField"/>
             <span class="smallNote">${HINT_REPORTING_SARIF_FILE}</span>
         </td>
     </tr>
@@ -493,7 +521,14 @@
             <label for="${REPORTING_SONARGIIF_FILE}">${LABEL_REPORTING_SONARGIIF_FILE}<l:star/></label>
         </th>
         <td class="noBorder dense">
-            <props:textProperty name="${REPORTING_SONARGIIF_FILE}" className="longField"/>
+            <props:textProperty
+                    name="${REPORTING_SONARGIIF_FILE}"
+                    value="${
+                        propertiesBean.properties[REPORTING_SONARGIIF] == FALSE
+                        ? DEFAULT_REPORTING_SONARGIIF_FILE
+                        : propertiesBean.properties[REPORTING_SONARGIIF_FILE]
+                    }"
+                    className="longField"/>
             <span class="smallNote">${HINT_REPORTING_SONARGIIF_FILE}</span>
         </td>
     </tr>
@@ -656,4 +691,3 @@
     </tr>
     </tbody>
 </l:settingsGroup>
-


### PR DESCRIPTION
Теперь проставляются стандартные имена файлов и стандартный шаблон в `Reporting: save AST results report file`

В случае, когда UI сервера на русском, а UI у teamcity на английском (язык шаблона выставляется в зависимости от последнего), все работает корректно 

<img width="760" alt="image" src="https://github.com/user-attachments/assets/590cb61f-f9f4-4f27-92a8-cbef09afee6d">
<img width="760" alt="image" src="https://github.com/user-attachments/assets/c6de3538-b4f5-449d-8cf2-c311d47df011">
