### PR TITLE
ASINT-180: Fix “PT AI client token must not be empty.” after entering the token

### DIFF
--- a/ptai-jenkins-plugin/src/main/resources/com/ptsecurity/appsec/ai/ee/utils/ci/integration/plugin/jenkins/credentials/CredentialsImpl/config.groovy
+++ b/ptai-jenkins-plugin/src/main/resources/com/ptsecurity/appsec/ai/ee/utils/ci/integration/plugin/jenkins/credentials/CredentialsImpl/config.groovy
@@ -7,7 +7,7 @@ def st = namespace("jelly:stapler")
 f.entry(
         title: _('token'),
         field: 'token') {
-    f.password()
+    f.password(checkMethod: 'post', onkeyup: "this.onchange()")
 }
 
 f.entry(


### PR DESCRIPTION
Добавлен явный вызов валидации после каждого изменения в поле (не на изменение фокуса).
  
Так вызывается метод doCheckToken из класса CredentialsImpl.

До фикса баг у меня воспроизводился