### PR TITLE
ASINT-2340: Fix Internal server error while "Remove prefix" is invalid

### DIFF
--- a/generic-client-lib/src/main/java/com/ptsecurity/appsec/ai/ee/utils/ci/integration/utils/FileCollector.java
+++ b/generic-client-lib/src/main/java/com/ptsecurity/appsec/ai/ee/utils/ci/integration/utils/FileCollector.java
@@ -24,6 +24,7 @@ import org.apache.tools.ant.types.FileSet;
 import java.io.*;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.text.DecimalFormat;
 import java.util.*;
 
@@ -144,7 +145,7 @@ public class FileCollector {
                     FilenameUtils.separatorsToUnix(
                             FilenameUtils.normalize(transfer.getRemovePrefix() + "/")))
                     .orElse("");
-            if ('/' == removePrefix.charAt(0))
+            if (!removePrefix.isEmpty() && '/' == removePrefix.charAt(0))
                 removePrefix = removePrefix.substring(1);
             verbose("Pattern separator = %s", transfer.getPatternSeparator().isEmpty() ? "[empty]" : transfer.getPatternSeparator());
             verbose("Remove prefix = %s", removePrefix.isEmpty() ? "[empty]" : removePrefix);
@@ -190,11 +191,17 @@ public class FileCollector {
                     if (transfer.isFlatten()) {
                         if (0 == i) continue;
                         entryName = itemPath.getFileName().toString();
+                    } else if (relativePath.equals(removePrefix)) {
+                        continue;
                     } else {
                         if (!relativePath.startsWith(removePrefix))
                             throw GenericException.raise("File collect failed", new IllegalArgumentException(String.format("File's %s does not starts with prefix %s", item, removePrefix)));
                         entryName = StringUtils.removeStart(relativePath, removePrefix);
                     }
+                    if (entryName.startsWith("/")) {
+                        entryName = entryName.substring(1);
+                    }
+
                     verbose("File %s will be added as %s", itemPath.toString(), entryName);
                     res.add(new Entry(itemPath, entryName));
                 }


### PR DESCRIPTION
Теперь это работает так:

Такие настройки валидны (из-за `/**` в конце параметра Files to analyse) тк мы указываем, брать для сканирования любые файлы из этой директории
<img width="775" alt="image" src="https://github.com/user-attachments/assets/52c12c0a-db3f-4f76-8224-5455a9a76307" />

Такие тоже валидны
<img width="775" alt="image" src="https://github.com/user-attachments/assets/07f70138-2db5-44a9-9539-76bbf2904fe2" />

При таком варианте ZIP архив, отправляемый на сервер, создается без директорий `exploits/zip-slip`, но с файлами из `exploits/zip-slip` -> пути к файлам в результатах сканирования будут сокращены с ./exploits/zip-slip/someFile.js до ./someFile.js

С такими будет ошибка
<img width="775" alt="image" src="https://github.com/user-attachments/assets/812d6bfc-d649-4428-a34a-183a81daa50b" />
<img width="775" alt="image" src="https://github.com/user-attachments/assets/35fa0f8a-8df2-4b11-97a9-37e22a813e39" />

Сама ошибка
<img width="933" alt="image" src="https://github.com/user-attachments/assets/90c12393-82f7-404d-8a0f-cf1d5e6a6a54" />


