### PR TITLE
ASINT-3413: Fix for specifying project name/id and branch when issuing a report from cli

### DIFF
--- a/ptai-cli-plugin/src/main/java/com/ptsecurity/appsec/ai/ee/utils/ci/integration/cli/commands/GenerateReport.java
+++ b/ptai-cli-plugin/src/main/java/com/ptsecurity/appsec/ai/ee/utils/ci/integration/cli/commands/GenerateReport.java
@@ -45,15 +45,14 @@ public class GenerateReport extends BaseCommand implements Callable<Integer> {
                 paramLabel = "<UUID>",
                 description = "PT AI project Id")
         UUID id;
-
-        @CommandLine.Option(
-                names = {"-b", "--branch-name"},
-                order = 4,
-                paramLabel = "<name>",
-                description = "PT AI branch name")
-        protected String branchName = null;
-
     }
+
+    @CommandLine.Option(
+            names = {"-b", "--branch-name"},
+            order = 4,
+            paramLabel = "<name>",
+            description = "PT AI branch name")
+    protected String branchName = null;
 
     @CommandLine.ArgGroup(multiplicity = "1")
     protected ProjectInfo projectInfo = null;
@@ -115,7 +114,7 @@ public class GenerateReport extends BaseCommand implements Callable<Integer> {
                         .build())
                 .projectId(projectInfo.id)
                 .projectName(projectInfo.name)
-                .branchName(projectInfo.branchName)
+                .branchName(branchName)
                 .scanResultId(scanResultId)
                 .output(output)
                 .reports(reports.convert())


### PR DESCRIPTION
Исправил ошибку, что branch-name взаимоисключал с project-name/project-id