### PR TITLE
ASINT-3565: Support for version 5.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -264,3 +264,5 @@ options:
   + "Custom branch" if you need to specify a branch manually (enter a name in the Branch name field)
 + [Feature] Added the --branch-name CLI parameter to scan a specified branch (creates it if missing)
 + [Feature] Removed Jenkins and TeamCity builds from the CLI plugin's Dockerfile
+### 20250728
++ [Feature] PT AI v.5.1.0 support approved

--- a/generic-client-lib/src/main/java/com/ptsecurity/appsec/ai/ee/utils/ci/integration/api/v500/ApiClient.java
+++ b/generic-client-lib/src/main/java/com/ptsecurity/appsec/ai/ee/utils/ci/integration/api/v500/ApiClient.java
@@ -41,13 +41,12 @@ import java.security.SecureRandom;
 import java.util.*;
 import java.util.concurrent.BlockingQueue;
 
-import static com.ptsecurity.appsec.ai.ee.server.v500.auth.model.AuthScope.ACCESSTOKEN;
 import static com.ptsecurity.appsec.ai.ee.server.v500.auth.model.AuthScope.WEB;
 import static com.ptsecurity.appsec.ai.ee.server.v500.notifications.model.Stage.*;
 import static com.ptsecurity.misc.tools.helpers.CallHelper.call;
 
 @Slf4j
-@VersionRange(min = {5, 0, 0, 0}, max = {5, 0, 99999, 99999})
+@VersionRange(min = {5, 0, 0, 0}, max = {5, 1, 99999, 99999})
 public class ApiClient extends AbstractApiClient {
     @Getter
     protected final String id = UUID.randomUUID().toString();

--- a/generic-client-lib/src/main/java/com/ptsecurity/appsec/ai/ee/utils/ci/integration/api/v500/tasks/GenericAstTasksImpl.java
+++ b/generic-client-lib/src/main/java/com/ptsecurity/appsec/ai/ee/utils/ci/integration/api/v500/tasks/GenericAstTasksImpl.java
@@ -104,10 +104,10 @@ public class GenericAstTasksImpl extends AbstractTaskImpl implements GenericAstT
             return "default";
         }
 
-        String oldestBranchName = getWorkingBranchModel(projectId, branches).getName();
+        String workingBranchName = Objects.requireNonNull(getWorkingBranchModel(projectId, branches)).getName();
 
-        if (oldestBranchName != null) {
-            return oldestBranchName;
+        if (workingBranchName != null) {
+            return workingBranchName;
         }
 
         return "default";
@@ -160,6 +160,15 @@ public class GenericAstTasksImpl extends AbstractTaskImpl implements GenericAstT
     }
 
     private BranchModel getWorkingBranchModel(@NonNull UUID projectId, List<BranchModel> branches) {
+        BranchModel workingBranch = branches.stream()
+                .filter(BranchModel::getIsWorking)
+                .findFirst()
+                .orElse(null);
+
+        if (workingBranch != null) {
+            return workingBranch;
+        }
+
         List<BranchWithScanInfoModel> branchesWithScanInfoModel = call(
                 () -> client.getProjectsApi().apiProjectsProjectIdBranchesWithScansGet(projectId),
                 "PT AI get branches failed"

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,7 +11,7 @@ jenkinsIncrementalRepoUrl=https://repo.jenkins-ci.org/incremental/
 teamcityRepoUrl=https://download.jetbrains.com/teamcity-repository/
 
 rootGroup=com.ptsecurity.appsec.ai.ee.utils.ci.integration
-version=5.0.0
+version=5.1.0
 junitVersion=5.7.2
 slf4jVersion=2.0.7
 log4jVersion=2.20.0


### PR DESCRIPTION
Работает как с 5.0.0, так и с 5.1.0

Плюс, немного изменил то, как получается working ветка. Работу api пофиксили в AIPS-23941, теперь в 5.1.0 флаг isWorking корректно проставляется и при получении всех веток ручкой `/api/projects/{projectId}/branches [GET]`