### PR TITLE
ASINT-3593: Fix json policy validation in TeamCity while policy is empty

### DIFF
--- a/ptai-teamcity-plugin/ptai-teamcity-plugin-agent/src/main/java/com/ptsecurity/appsec/ai/ee/utils/ci/integration/plugin/teamcity/agent/AstBuildProcess.java
+++ b/ptai-teamcity-plugin/ptai-teamcity-plugin-agent/src/main/java/com/ptsecurity/appsec/ai/ee/utils/ci/integration/plugin/teamcity/agent/AstBuildProcess.java
@@ -77,7 +77,10 @@ public class AstBuildProcess implements BuildProcess, Callable<BuildFinishedStat
         String policy = null;
         if (!selectedScanSettingsUi) {
             settings = BaseJsonHelper.minimize(params.get(Params.JSON_SETTINGS));
-            policy = BaseJsonHelper.minimize(params.get(Params.JSON_POLICY));
+            String policyParamValue = params.get(Params.JSON_POLICY);
+            if (policyParamValue != null) {
+                policy = BaseJsonHelper.minimize(params.get(Params.JSON_POLICY));
+            }
         } else
             projectName = params.get(Params.PROJECT_NAME);
 

--- a/ptai-teamcity-plugin/ptai-teamcity-plugin-server/src/main/java/com/ptsecurity/appsec/ai/ee/utils/ci/integration/plugin/teamcity/service/AstSettingsService.java
+++ b/ptai-teamcity-plugin/ptai-teamcity-plugin-server/src/main/java/com/ptsecurity/appsec/ai/ee/utils/ci/integration/plugin/teamcity/service/AstSettingsService.java
@@ -386,7 +386,11 @@ public class AstSettingsService {
                 UnifiedAiProjScanSettings settings = UnifiedAiProjScanSettings.loadSettings(bean.getProperties().get(JSON_SETTINGS));
                 results.add("JSON settings are verified, project name is " + settings.getProjectName());
                 Policy[] policyJson = JsonPolicyHelper.verify(bean.getProperties().get(JSON_POLICY));
-                results.add("JSON policy is verified, number of rule sets is " + policyJson.length);
+                if (policyJson != null) {
+                    results.add("JSON policy is verified, number of rule sets is " + policyJson.length);
+                } else {
+                    results.add("JSON policy is verified");
+                }
             }
 
             // Check reporting settings


### PR DESCRIPTION
До этого было разное поведение в настройках Jenkins и TeamCity. При пустом поле json policy в Jenkins не было ошибки, а в TeamCity была, сейчас ошибки нет в обоих плагинах