### PR TITLE
ASINT-4172: Add scan label to json and sarif reports

### DIFF
--- a/generic-client-lib/src/main/java/com/ptsecurity/appsec/ai/ee/utils/ci/integration/api/v530/converters/IssuesConverter.java
+++ b/generic-client-lib/src/main/java/com/ptsecurity/appsec/ai/ee/utils/ci/integration/api/v530/converters/IssuesConverter.java
@@ -400,6 +400,12 @@ public class IssuesConverter {
         destination.setId(Objects.requireNonNull(scanResult.getId(), "Scan result ID is null"));
         destination.setProjectId(Objects.requireNonNull(scanResult.getProjectId(), "Scan result project ID is null"));
         destination.setProjectName(projectName);
+
+        Optional.of(scanResult)
+                .map(ScanResultModel::getScanLabel)
+                .filter(StringUtils::isNotEmpty)
+                .ifPresent(destination::setScanLabel);
+
         destination.setScanSettings(convert(scanSettings));
 
         ScanStatisticModel statistic = Objects.requireNonNull(scanResult.getStatistic(), "Scan result statistics is null");

--- a/generic-client-lib/src/main/java/com/ptsecurity/appsec/ai/ee/utils/ci/integration/jobs/subjobs/export/Sarif.java
+++ b/generic-client-lib/src/main/java/com/ptsecurity/appsec/ai/ee/utils/ci/integration/jobs/subjobs/export/Sarif.java
@@ -80,6 +80,8 @@ public class Sarif extends Export {
         Tool sarifTool = new Tool();
         sarifRun.setTool(sarifTool);
 
+        setScanLabel(scanResult, sarifRun);
+
         ToolComponent driver = new ToolComponent()
                 .withName("Positive Technologies Application Inspector")
                 .withInformationUri(new URI("https://www.ptsecurity.com/ww-en/products/ai/"))
@@ -234,5 +236,19 @@ public class Sarif extends Export {
         if (isEmpty(placeList)) return;
         for (BaseSourceIssue.Place place : placeList)
             if (null != place) list.add(tfl(place, text));
+    }
+
+    @SneakyThrows
+    private static void setScanLabel(ScanResult scanResult, Run sarifRun) {
+        String scanLabel = scanResult.getScanLabel();
+        if (scanLabel == null){
+            return;
+        }
+
+        sarifRun.setVersionControlProvenance(Collections.singleton(
+                new VersionControlDetails()
+                        .withRepositoryUri(URI.create("http://localhost"))
+                        .withRevisionId(scanLabel)
+        ));
     }
 }


### PR DESCRIPTION
Добавил scan label в sarif также, как это выглядит в отчете от aie. В giif добавлять не стал, тк в этом отчете нет ничего, кроме данных об уязвимостях (== массив с уязвимостями) и нет имени проекта, имени ветки, и id скана и так далее