### PR TITLE
ASL2-5293: Fix org.apache.commons.compress dependency in Jenkins

### DIFF
--- a/generic-client-lib/build.gradle
+++ b/generic-client-lib/build.gradle
@@ -11,7 +11,7 @@ dependencies {
     api project(':ptai-rest-api')
 
     // https://mvnrepository.com/artifact/org.apache.commons/commons-compress
-    implementation 'org.apache.commons:commons-compress:1.21'
+    implementation 'org.apache.commons:commons-compress:1.28.0'
     // Need this to work with 7zip compression
     // https://mvnrepository.com/artifact/org.tukaani/xz
     implementation 'org.tukaani:xz:1.9'

--- a/pt-misc-tools/build.gradle
+++ b/pt-misc-tools/build.gradle
@@ -8,7 +8,7 @@ group = "${rootGroup}"
 dependencies {
     // Support zip archives
     // https://mvnrepository.com/artifact/org.apache.commons/commons-compress
-    api 'org.apache.commons:commons-compress:1.21'
+    api 'org.apache.commons:commons-compress:1.28.0'
     // 7zip archives support
     // https://mvnrepository.com/artifact/org.tukaani/xz
     api 'org.tukaani:xz:1.9'

--- a/ptai-jenkins-plugin/build.gradle
+++ b/ptai-jenkins-plugin/build.gradle
@@ -31,10 +31,10 @@ jenkinsPlugin {
     gitHubUrl = 'https://github.com/POSIdev-community/ptai-ee-tools.git'
 
     // use the plugin class loader before the core class loader, defaults to false
-    // pluginFirstClassLoader = true
+    pluginFirstClassLoader = true
 
     // optional list of package prefixes that your plugin doesn't want to see from core
-    // maskClasses = 'groovy.grape org.apache.commons.codec'
+    maskClasses = 'org.apache.commons.compress'
 
     // optional version number from which this plugin release is configuration-compatible
     // compatibleSinceVersion = '1.1.0'


### PR DESCRIPTION
Ошибка была в том, в плагине использовалась зависимость `org.apache.commons:commons-compress:1.28.0`, но в рантайме Jenkins подтягивал библиотеку с версией ниже, в которой не было реализации метода `putArchiveEntry()`. 

Везде обновил `org.apache.commons:commons-compress` до нужной версии, добавил свойства, явно указывающие Jenkins использовать зависимости из плагина, а не своего ядра, проверил остальные зависимости на то, что они не подтягивают старые версии библиотеки