### PR TITLE
AIDT-31: Fix token broadcast to every build

### DIFF
--- a/ptai-teamcity-plugin/ptai-teamcity-plugin-agent/src/main/java/com/ptsecurity/appsec/ai/ee/utils/ci/integration/plugin/teamcity/agent/AstBuildProcess.java
+++ b/ptai-teamcity-plugin/ptai-teamcity-plugin-agent/src/main/java/com/ptsecurity/appsec/ai/ee/utils/ci/integration/plugin/teamcity/agent/AstBuildProcess.java
@@ -80,7 +80,6 @@ public class AstBuildProcess implements BuildProcess, Callable<BuildFinishedStat
 
     private AbstractJob.JobExecutionResult ast() {
         Map<String, String> params = buildRunnerContext.getRunnerParameters();
-        Map<String, String> globals = agentRunningBuild.getSharedConfigParameters();
 
         boolean selectedScanSettingsUi = AST_SETTINGS_UI.equals(params.get(Params.AST_SETTINGS));
         String projectName = null;
@@ -118,10 +117,6 @@ public class AstBuildProcess implements BuildProcess, Callable<BuildFinishedStat
         transfer.setUseDefaultExcludes(TRUE.equalsIgnoreCase(params.get(Params.USE_DEFAULT_EXCLUDES)));
         Transfers transfers = new Transfers().addTransfer(transfer);
 
-        Map<String, String> activeConnectionParams = SERVER_SETTINGS_LOCAL.equals(params.get(Params.SERVER_SETTINGS))
-                ? params
-                : globals;
-
         String branchName = getBranchName(params);
         String scanLabel =  params.get(Params.SCAN_LABEL);
         String projectPriority = getProjectPriority(params);
@@ -136,10 +131,10 @@ public class AstBuildProcess implements BuildProcess, Callable<BuildFinishedStat
                 .settings(selectedScanSettingsUi ? null : settings)
                 .policy(selectedScanSettingsUi ?  null : policy)
                 .connectionSettings(ConnectionSettings.builder()
-                        .url(activeConnectionParams.get(Params.URL))
-                        .insecure(TRUE.equals(activeConnectionParams.get(Params.INSECURE)))
-                        .credentials(TokenCredentials.builder().token(activeConnectionParams.get(Params.TOKEN)).build())
-                        .caCertsPem(activeConnectionParams.get(Params.CERTIFICATES))
+                        .url(params.get(Params.URL))
+                        .insecure(TRUE.equals(params.get(Params.INSECURE)))
+                        .credentials(TokenCredentials.builder().token(params.get(Params.TOKEN)).build())
+                        .caCertsPem(params.get(Params.CERTIFICATES))
                         .build())
                 .fullScanMode(TRUE.equals(params.get(Params.FULL_SCAN_MODE)))
                 .verbose(TRUE.equals(params.get(Params.VERBOSE)))

--- a/ptai-teamcity-plugin/ptai-teamcity-plugin-server/src/main/java/com/ptsecurity/appsec/ai/ee/utils/ci/integration/plugin/teamcity/runner/AstBuildStartContextProcessor.java
+++ b/ptai-teamcity-plugin/ptai-teamcity-plugin-server/src/main/java/com/ptsecurity/appsec/ai/ee/utils/ci/integration/plugin/teamcity/runner/AstBuildStartContextProcessor.java
@@ -4,6 +4,7 @@ import com.ptsecurity.appsec.ai.ee.utils.ci.integration.plugin.teamcity.admin.As
 import jetbrains.buildServer.ExtensionHolder;
 import jetbrains.buildServer.serverSide.BuildStartContext;
 import jetbrains.buildServer.serverSide.BuildStartContextProcessor;
+import jetbrains.buildServer.serverSide.SRunnerContext;
 import lombok.NonNull;
 
 import static com.ptsecurity.appsec.ai.ee.utils.ci.integration.plugin.teamcity.Params.*;
@@ -27,16 +28,28 @@ public class AstBuildStartContextProcessor implements BuildStartContextProcessor
     }
 
     /**
-     * Adds globally defined parameter values to agent job as these parameters aren't
-     * part of build step configuration
+     * Adds globally defined parameter values to those PT AI AST steps that are set up to use global
+     * connection settings. Values are added as a step-scoped runner parameters and not as a build-wide
+     * shared ones, so builds without AST step get no PT AI credentials at all and steps that share
+     * a build with an AST one can't read the PT AI token
      * @param context Agent job context
      */
     @Override
     public void updateParameters(@NonNull BuildStartContext context) {
-        context.addSharedParameter(URL, settings.getValue(URL));
-        context.addSharedParameter(TOKEN, settings.getValue(TOKEN));
-        context.addSharedParameter(CERTIFICATES, settings.getValue(CERTIFICATES));
-        context.addSharedParameter(INSECURE, settings.getValue(INSECURE));
+        for (SRunnerContext runner : context.getRunnerContexts()) {
+            if (!runner.isEnabled()) {
+                continue;
+            }
+
+            if (!AstRunnerSettings.usesGlobalConnectionSettings(runner)) {
+                continue;
+            }
+
+            runner.addRunnerParameter(URL, settings.getValue(URL));
+            runner.addRunnerParameter(TOKEN, settings.getValue(TOKEN));
+            runner.addRunnerParameter(CERTIFICATES, settings.getValue(CERTIFICATES));
+            runner.addRunnerParameter(INSECURE, settings.getValue(INSECURE));
+        }
     }
 
     public void register() {

--- a/ptai-teamcity-plugin/ptai-teamcity-plugin-server/src/main/java/com/ptsecurity/appsec/ai/ee/utils/ci/integration/plugin/teamcity/runner/AstPasswordsProvider.java
+++ b/ptai-teamcity-plugin/ptai-teamcity-plugin-server/src/main/java/com/ptsecurity/appsec/ai/ee/utils/ci/integration/plugin/teamcity/runner/AstPasswordsProvider.java
@@ -1,0 +1,62 @@
+package com.ptsecurity.appsec.ai.ee.utils.ci.integration.plugin.teamcity.runner;
+
+import com.ptsecurity.appsec.ai.ee.utils.ci.integration.plugin.teamcity.admin.AstAdminSettings;
+import jetbrains.buildServer.ExtensionHolder;
+import jetbrains.buildServer.serverSide.BuildTypeNotFoundException;
+import jetbrains.buildServer.serverSide.Parameter;
+import jetbrains.buildServer.serverSide.SBuild;
+import jetbrains.buildServer.serverSide.SimpleParameter;
+import jetbrains.buildServer.serverSide.parameters.types.PasswordsProvider;
+import jetbrains.buildServer.util.StringUtil;
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Collection;
+import java.util.Collections;
+
+import static com.ptsecurity.appsec.ai.ee.utils.ci.integration.plugin.teamcity.Params.TOKEN;
+
+@Slf4j
+public class AstPasswordsProvider implements PasswordsProvider {
+    private final ExtensionHolder extensionHolder;
+
+    @NonNull
+    private final AstAdminSettings settings;
+
+    public AstPasswordsProvider(
+            @NonNull final ExtensionHolder extensionHolder,
+            @NonNull final AstAdminSettings settings) {
+        this.extensionHolder = extensionHolder;
+        this.settings = settings;
+    }
+
+    @NotNull
+    @Override
+    public Collection<Parameter> getPasswordParameters(@NotNull final SBuild build) {
+        String token = settings.getValue(TOKEN);
+        if (StringUtil.isEmpty(token)) {
+            return Collections.emptyList();
+        }
+
+        if (!usesGlobalToken(build)){
+            return Collections.emptyList();
+        }
+
+        return Collections.singleton(new SimpleParameter(TOKEN, token));
+    }
+
+    private boolean usesGlobalToken(@NotNull final SBuild build) {
+        try {
+            return build.getBuildPromotion().getBuildSettings().getBuildRunners().stream()
+                    .anyMatch(AstRunnerSettings::usesGlobalConnectionSettings);
+        } catch (BuildTypeNotFoundException e) {
+            log.debug("Failed to get settings of the build {}, no PT AI token to hide", build.getBuildId(), e);
+            return false;
+        }
+    }
+
+    public void register() {
+        extensionHolder.registerExtension(PasswordsProvider.class, this.getClass().getName(), this);
+    }
+}

--- a/ptai-teamcity-plugin/ptai-teamcity-plugin-server/src/main/java/com/ptsecurity/appsec/ai/ee/utils/ci/integration/plugin/teamcity/runner/AstRunnerSettings.java
+++ b/ptai-teamcity-plugin/ptai-teamcity-plugin-server/src/main/java/com/ptsecurity/appsec/ai/ee/utils/ci/integration/plugin/teamcity/runner/AstRunnerSettings.java
@@ -1,0 +1,15 @@
+package com.ptsecurity.appsec.ai.ee.utils.ci.integration.plugin.teamcity.runner;
+
+import jetbrains.buildServer.serverSide.ParametersDescriptor;
+import lombok.NonNull;
+
+import static com.ptsecurity.appsec.ai.ee.utils.ci.integration.plugin.teamcity.Constants.RUNNER_TYPE;
+import static com.ptsecurity.appsec.ai.ee.utils.ci.integration.plugin.teamcity.Constants.SERVER_SETTINGS_LOCAL;
+import static com.ptsecurity.appsec.ai.ee.utils.ci.integration.plugin.teamcity.Params.SERVER_SETTINGS;
+
+public class AstRunnerSettings {
+    public static boolean usesGlobalConnectionSettings(@NonNull final ParametersDescriptor runner) {
+        return RUNNER_TYPE.equals(runner.getType())
+                && !SERVER_SETTINGS_LOCAL.equals(runner.getParameters().get(SERVER_SETTINGS));
+    }
+}

--- a/ptai-teamcity-plugin/ptai-teamcity-plugin-server/src/main/resources/META-INF/build-server-plugin-ptai-teamcity-plugin.xml
+++ b/ptai-teamcity-plugin/ptai-teamcity-plugin-server/src/main/resources/META-INF/build-server-plugin-ptai-teamcity-plugin.xml
@@ -9,6 +9,7 @@
     <bean class="com.ptsecurity.appsec.ai.ee.utils.ci.integration.plugin.teamcity.admin.AstAdminPageController"/>
     <bean class="com.ptsecurity.appsec.ai.ee.utils.ci.integration.plugin.teamcity.runner.AstRunType"/>
     <bean class="com.ptsecurity.appsec.ai.ee.utils.ci.integration.plugin.teamcity.runner.AstBuildStartContextProcessor" init-method="register"/>
+    <bean class="com.ptsecurity.appsec.ai.ee.utils.ci.integration.plugin.teamcity.runner.AstPasswordsProvider" init-method="register"/>
     <bean class="com.ptsecurity.appsec.ai.ee.utils.ci.integration.plugin.teamcity.runner.AstEditRunTypeControllerExtension"/>
     <bean class="com.ptsecurity.appsec.ai.ee.utils.ci.integration.plugin.teamcity.runner.AstSettingsPageController"/>
 </beans>


### PR DESCRIPTION
1. Параметры кладутся не в билд целиком, а только в конкретные шаги PT AI, которые настроены на глобальные настройки. Билд без шага PT AI не получает вообще ничего; соседний шаг внутри билда с PT AI.
2. Токен помечен секретным == он маскируется звёздочками в логах. 