### PR TITLE
AIDT-28: Add PT AI address allow list and generalize connection-check errors

### DIFF
--- a/ptai-teamcity-plugin/ptai-teamcity-plugin-common/src/main/java/com/ptsecurity/appsec/ai/ee/utils/ci/integration/plugin/teamcity/Constants.java
+++ b/ptai-teamcity-plugin/ptai-teamcity-plugin-common/src/main/java/com/ptsecurity/appsec/ai/ee/utils/ci/integration/plugin/teamcity/Constants.java
@@ -49,6 +49,8 @@ public class Constants {
     public static final String SERVER_SETTINGS_GLOBAL = "SettingsGlobal";
     public static final String SERVER_SETTINGS_LOCAL = "SettingsTask";
 
+    public static final String ALLOWED_URLS = PREFIX + "AllowedUrls";
+
     /**
      * AST job is to be executed in synchronous mode i.e. CI system will wait
      * for job to finish, then look at the AST policy assessment results, generate reports etc.

--- a/ptai-teamcity-plugin/ptai-teamcity-plugin-common/src/main/java/com/ptsecurity/appsec/ai/ee/utils/ci/integration/plugin/teamcity/Hints.java
+++ b/ptai-teamcity-plugin/ptai-teamcity-plugin-common/src/main/java/com/ptsecurity/appsec/ai/ee/utils/ci/integration/plugin/teamcity/Hints.java
@@ -17,6 +17,15 @@ public class Hints {
     public static final String CERTIFICATES = Resources.i18n_ast_settings_server_ca_pem_hint();
     public static final String INSECURE = Resources.i18n_ast_settings_server_insecure_hint();
 
+    public static final String INSECURE_SCOPE =
+            "This option applies to both global and task-scope (project) connection settings.";
+
+    public static final String ALLOWED_URLS =
+            "PT AI server addresses (one per line) that task-scope build steps may connect to. " +
+                    "Build steps using task-scope connection settings can only pick an address from this list. " +
+                    "This list is independent of the PT AI server URL above: that URL is not added here " +
+                    "automatically, so leave this empty to forbid task-scope addresses entirely.";
+
     public static final String SERVER_SETTINGS = "Choose how PT AI server connection settings are defined";
     public static final String SERVER_SETTINGS_GLOBAL = "Global scope defined PT AI server config";
     public static final String SERVER_SETTINIGS_LOCAL = "Task scope defined PT AI server config";

--- a/ptai-teamcity-plugin/ptai-teamcity-plugin-common/src/main/java/com/ptsecurity/appsec/ai/ee/utils/ci/integration/plugin/teamcity/Labels.java
+++ b/ptai-teamcity-plugin/ptai-teamcity-plugin-common/src/main/java/com/ptsecurity/appsec/ai/ee/utils/ci/integration/plugin/teamcity/Labels.java
@@ -17,6 +17,9 @@ public class Labels {
     public static final String CERTIFICATES = Resources.i18n_ast_settings_server_ca_pem_label();
     public static final String INSECURE = Resources.i18n_ast_settings_server_insecure_label();
 
+    public static final String ALLOWED_URLS = "Allowed PT AI server addresses";
+    public static final String ALLOWED_URLS_SELECT = "-- Select an allowed PT AI server address --";
+
     // Task settings labels
     public static final String SERVER_SETTINGS = "PT AI server connection";
     public static final String SERVER_SETTINGS_GLOBAL = "Globally defined";

--- a/ptai-teamcity-plugin/ptai-teamcity-plugin-common/src/main/java/com/ptsecurity/appsec/ai/ee/utils/ci/integration/plugin/teamcity/Messages.java
+++ b/ptai-teamcity-plugin/ptai-teamcity-plugin-common/src/main/java/com/ptsecurity/appsec/ai/ee/utils/ci/integration/plugin/teamcity/Messages.java
@@ -3,6 +3,9 @@ package com.ptsecurity.appsec.ai.ee.utils.ci.integration.plugin.teamcity;
 public class Messages {
     public static final String MESSAGE_GLOBAL_SETTINGS_INVALID = "Global connection settings are invalid";
 
+    public static final String MESSAGE_URL_NOT_ALLOWED = "PT AI server URL is not in the list of addresses allowed by the administrator";
+    public static final String MESSAGE_CONNECTION_CHECK_FAILED = "PT AI server connection check failed. Please contact your administrator or check the TeamCity server logs for details";
+
     public static final String MESSAGE_CUSTOM_BRANCH_NAME_EMPTY = "Custom branch name must not be empty";
     public static final String MESSAGE_JSON_SETTINGS_EMPTY = "JSON-defined scan settings must not be empty";
     public static final String MESSAGE_CUSTOM_BRANCH_NAME_TOO_LONG = "Custom branch name exceeds the length of 512 characters";

--- a/ptai-teamcity-plugin/ptai-teamcity-plugin-server/src/main/java/com/ptsecurity/appsec/ai/ee/utils/ci/integration/plugin/teamcity/admin/AstAdminPageController.java
+++ b/ptai-teamcity-plugin/ptai-teamcity-plugin-server/src/main/java/com/ptsecurity/appsec/ai/ee/utils/ci/integration/plugin/teamcity/admin/AstAdminPageController.java
@@ -21,6 +21,7 @@ import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
 import static com.ptsecurity.appsec.ai.ee.utils.ci.integration.plugin.teamcity.Constants.ADMIN_CONTROLLER_PATH;
+import static com.ptsecurity.appsec.ai.ee.utils.ci.integration.plugin.teamcity.Constants.ALLOWED_URLS;
 import static com.ptsecurity.appsec.ai.ee.utils.ci.integration.plugin.teamcity.Params.*;
 
 @Slf4j
@@ -53,7 +54,12 @@ public class AstAdminPageController extends BaseAstController {
             return;
         }
 
-        PropertiesBean bean = new PropertiesBean().fill(URL, request).fill(CERTIFICATES, request).fill(INSECURE, request).fillSecret(TOKEN, request);
+        PropertiesBean bean = new PropertiesBean()
+                .fill(URL, request)
+                .fill(CERTIFICATES, request)
+                .fill(INSECURE, request)
+                .fill(ALLOWED_URLS, request)
+                .fillSecret(TOKEN, request);
 
         String mode = request.getParameter("mode");
         if ("modify".equalsIgnoreCase(mode))
@@ -61,7 +67,9 @@ public class AstAdminPageController extends BaseAstController {
         else {
             // Check if settings passed as a subject to save or to test connection are correct
             if ("test".equalsIgnoreCase(mode)) {
-                AstSettingsService.VerificationResults results = AstSettingsService.checkConnectionSettings(bean, false);
+                AstSettingsService.VerificationResults results = AstSettingsService
+                        .checkConnectionSettings(bean, null, false);
+
                 saveVerificationResults(xml, results);
             } else if (mode.equals("save")) {
                 bean.getProperties().forEach(settings::setValue);

--- a/ptai-teamcity-plugin/ptai-teamcity-plugin-server/src/main/java/com/ptsecurity/appsec/ai/ee/utils/ci/integration/plugin/teamcity/admin/AstAdminSettings.java
+++ b/ptai-teamcity-plugin/ptai-teamcity-plugin-server/src/main/java/com/ptsecurity/appsec/ai/ee/utils/ci/integration/plugin/teamcity/admin/AstAdminSettings.java
@@ -15,6 +15,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Properties;
 
+import static com.ptsecurity.appsec.ai.ee.utils.ci.integration.plugin.teamcity.Constants.ALLOWED_URLS;
 import static com.ptsecurity.appsec.ai.ee.utils.ci.integration.plugin.teamcity.Params.*;
 
 public class AstAdminSettings {
@@ -63,6 +64,7 @@ public class AstAdminSettings {
         this.properties.put(TOKEN, scramble(Defaults.TOKEN));
         this.properties.put(CERTIFICATES, Defaults.CERTIFICATES);
         this.properties.put(INSECURE, Defaults.INSECURE);
+        this.properties.put(ALLOWED_URLS, "");
         getConfigFile().toFile().getParentFile().mkdirs();
         PropertiesUtil.storeProperties(properties, path.toFile(), "PT AI EE");
     }

--- a/ptai-teamcity-plugin/ptai-teamcity-plugin-server/src/main/java/com/ptsecurity/appsec/ai/ee/utils/ci/integration/plugin/teamcity/runner/AstBuildStartContextProcessor.java
+++ b/ptai-teamcity-plugin/ptai-teamcity-plugin-server/src/main/java/com/ptsecurity/appsec/ai/ee/utils/ci/integration/plugin/teamcity/runner/AstBuildStartContextProcessor.java
@@ -41,6 +41,11 @@ public class AstBuildStartContextProcessor implements BuildStartContextProcessor
                 continue;
             }
 
+            if (!AstRunnerSettings.isAstRunner(runner)) {
+                continue;
+            }
+
+            runner.addRunnerParameter(INSECURE, settings.getValue(INSECURE));
             if (!AstRunnerSettings.usesGlobalConnectionSettings(runner)) {
                 continue;
             }
@@ -48,7 +53,6 @@ public class AstBuildStartContextProcessor implements BuildStartContextProcessor
             runner.addRunnerParameter(URL, settings.getValue(URL));
             runner.addRunnerParameter(TOKEN, settings.getValue(TOKEN));
             runner.addRunnerParameter(CERTIFICATES, settings.getValue(CERTIFICATES));
-            runner.addRunnerParameter(INSECURE, settings.getValue(INSECURE));
         }
     }
 

--- a/ptai-teamcity-plugin/ptai-teamcity-plugin-server/src/main/java/com/ptsecurity/appsec/ai/ee/utils/ci/integration/plugin/teamcity/runner/AstEditRunTypeControllerExtension.java
+++ b/ptai-teamcity-plugin/ptai-teamcity-plugin-server/src/main/java/com/ptsecurity/appsec/ai/ee/utils/ci/integration/plugin/teamcity/runner/AstEditRunTypeControllerExtension.java
@@ -107,6 +107,8 @@ public class AstEditRunTypeControllerExtension implements EditRunTypeControllerE
                 });
         // We don't need publicKey property in the model as TeamCity did that for us
 
+        model.put("ptaiAllowedUrlList", AstSettingsService.parseAllowedUrls(settings));
+
         // Need to explicily call rememberState with newly added attributes
         // as editRunParams.jsp calls BS.EditBuildRunnerForm.setModified(${buildForm.buildRunnerBean.stateModified})
         // BuildRunnerBean's isStateModified calls getPropertiesBean().isStateModified() and as
@@ -139,7 +141,9 @@ public class AstEditRunTypeControllerExtension implements EditRunTypeControllerE
         // we need to inject those settings into bean prior to verification
         bean.injectGlobalSettings(settings);
 
-        AstSettingsService.VerificationResults results = AstSettingsService.checkConnectionSettings(bean, true);
+        AstSettingsService.VerificationResults results = AstSettingsService
+                .checkConnectionSettings(bean, settings, true);
+
         AstSettingsService.checkAstSettings(bean, results, true);
         ActionErrors errors = new ActionErrors();
         results.stream().filter(r -> null != r.getLeft()).forEach(e -> errors.addError(e.getLeft(), e.getRight()));

--- a/ptai-teamcity-plugin/ptai-teamcity-plugin-server/src/main/java/com/ptsecurity/appsec/ai/ee/utils/ci/integration/plugin/teamcity/runner/AstRunnerSettings.java
+++ b/ptai-teamcity-plugin/ptai-teamcity-plugin-server/src/main/java/com/ptsecurity/appsec/ai/ee/utils/ci/integration/plugin/teamcity/runner/AstRunnerSettings.java
@@ -8,8 +8,12 @@ import static com.ptsecurity.appsec.ai.ee.utils.ci.integration.plugin.teamcity.C
 import static com.ptsecurity.appsec.ai.ee.utils.ci.integration.plugin.teamcity.Params.SERVER_SETTINGS;
 
 public class AstRunnerSettings {
+    public static boolean isAstRunner(@NonNull final ParametersDescriptor runner) {
+        return RUNNER_TYPE.equals(runner.getType());
+    }
+
     public static boolean usesGlobalConnectionSettings(@NonNull final ParametersDescriptor runner) {
-        return RUNNER_TYPE.equals(runner.getType())
+        return isAstRunner(runner)
                 && !SERVER_SETTINGS_LOCAL.equals(runner.getParameters().get(SERVER_SETTINGS));
     }
 }

--- a/ptai-teamcity-plugin/ptai-teamcity-plugin-server/src/main/java/com/ptsecurity/appsec/ai/ee/utils/ci/integration/plugin/teamcity/runner/AstSettingsPageController.java
+++ b/ptai-teamcity-plugin/ptai-teamcity-plugin-server/src/main/java/com/ptsecurity/appsec/ai/ee/utils/ci/integration/plugin/teamcity/runner/AstSettingsPageController.java
@@ -65,11 +65,15 @@ public class AstSettingsPageController extends BaseAstController {
 
         if (MODE_MODIFY.equals(mode)) {
             // Perform as-you-type field validation
-            AstSettingsService.VerificationResults results = AstSettingsService.checkConnectionSettings(bean, true);
+            AstSettingsService.VerificationResults results = AstSettingsService
+                    .checkConnectionSettings(bean, settings, true);
+
             results = AstSettingsService.checkAstSettings(bean, results, true);
             saveVerificationResults(xml, results);
         } else if (MODE_TEST.equals(mode)) {
-            AstSettingsService.VerificationResults results = AstSettingsService.checkConnectionSettings(bean, false);
+            AstSettingsService.VerificationResults results = AstSettingsService
+                    .checkConnectionSettings(bean, settings, false);
+
             boolean connectionSettingsErrors = results.isFailure();
             // If connection failed then perform only parameters syntax validation and skip AST check
             results = AstSettingsService.checkAstSettings(bean, results, connectionSettingsErrors);

--- a/ptai-teamcity-plugin/ptai-teamcity-plugin-server/src/main/java/com/ptsecurity/appsec/ai/ee/utils/ci/integration/plugin/teamcity/service/AstSettingsService.java
+++ b/ptai-teamcity-plugin/ptai-teamcity-plugin-server/src/main/java/com/ptsecurity/appsec/ai/ee/utils/ci/integration/plugin/teamcity/service/AstSettingsService.java
@@ -24,15 +24,21 @@ import lombok.Getter;
 import lombok.NonNull;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 
+import javax.net.ssl.SSLException;
 import javax.servlet.http.HttpServletRequest;
+import java.net.UnknownHostException;
 import java.security.cert.X509Certificate;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
+import java.util.stream.Collectors;
 
 import static com.ptsecurity.appsec.ai.ee.ServerCheckResult.State.ERROR;
 import static com.ptsecurity.appsec.ai.ee.utils.ci.integration.plugin.teamcity.Constants.*;
@@ -86,14 +92,24 @@ public class AstSettingsService {
         }
     }
 
-    public static VerificationResults checkConnectionSettings(@NonNull final PropertiesBean bean, boolean parametersOnly) {
+    public static VerificationResults checkConnectionSettings(
+            @NonNull final PropertiesBean bean,
+            final AstAdminSettings settings,
+            boolean parametersOnly) {
         VerificationResults results = new VerificationResults();
-        return checkConnectionSettings(bean, results, parametersOnly);
+        return checkConnectionSettings(bean, settings, results, parametersOnly);
     }
 
-    public static VerificationResults checkConnectionSettings(@NonNull final PropertiesBean bean, @NonNull VerificationResults results, boolean parametersOnly) {
-        validateConnectionSettings(bean, results);
-        if (!parametersOnly && results.isSuccess()) checkConnectionSettings(bean, results);
+    public static VerificationResults checkConnectionSettings(
+            @NonNull final PropertiesBean bean,
+            final AstAdminSettings settings,
+            @NonNull VerificationResults results,
+            boolean parametersOnly) {
+        validateConnectionSettings(bean, settings, results);
+        if (!parametersOnly && results.isSuccess()) {
+            checkConnectionSettings(bean, results);
+        }
+
         return results;
     }
 
@@ -126,8 +142,7 @@ public class AstSettingsService {
             // If global settings mode is selected - init bean with global field values
             res.fill(URL, settings).fill(TOKEN, settings).fill(CERTIFICATES, settings).fill(INSECURE, settings);
         else if (SERVER_SETTINGS_LOCAL.equals(res.get(SERVER_SETTINGS))) {
-            // If task-scope settings mode is selected - init bean from request
-            res.fill(URL, request).fill(CERTIFICATES, request).fill(INSECURE, request);
+            res.fill(URL, request).fill(CERTIFICATES, request).fill(INSECURE, settings);
             String token = RSACipher.decryptWebRequestData(PropertiesBean.getEncryptedProperty(request, TOKEN));
             res.setProperty(TOKEN, token);
         }
@@ -188,6 +203,7 @@ public class AstSettingsService {
      */
     public static void validateConnectionSettings(
             @NonNull final PropertiesBean bean,
+            final AstAdminSettings settings,
             @NonNull final VerificationResults results) {
         // JavaScript handlers are named as on[Error ID]Error like "onEmptyUrlError"
 
@@ -200,6 +216,8 @@ public class AstSettingsService {
             temp.addError(URL, Resources.i18n_ast_settings_server_url_message_empty());
         else if (Validator.validateUrl(bean.get(URL)).fail())
             temp.addError(URL, Resources.i18n_ast_settings_server_url_message_invalid());
+        else if (null != settings && bean.eq(SERVER_SETTINGS, SERVER_SETTINGS_LOCAL) && !isUrlAllowed(bean.get(URL), settings))
+            temp.addError(URL, MESSAGE_URL_NOT_ALLOWED);
         if (bean.empty(TOKEN))
             temp.addError(TOKEN, Resources.i18n_ast_settings_server_token_message_empty());
         if (!bean.empty(CERTIFICATES)) {
@@ -221,6 +239,40 @@ public class AstSettingsService {
             else
                 results.add(SERVER_SETTINGS, MESSAGE_GLOBAL_SETTINGS_INVALID);
         }
+    }
+
+    @NonNull
+    public static List<String> parseAllowedUrls(final AstAdminSettings settings) {
+        if (null == settings) {
+            return Collections.emptyList();
+        }
+
+        return splitAllowedUrls(settings.getValue(ALLOWED_URLS));
+    }
+
+    @NonNull
+    static List<String> splitAllowedUrls(final String raw) {
+        if (StringUtils.isEmpty(raw)) {
+            return Collections.emptyList();
+        }
+
+        return Arrays.stream(raw.split("\\R"))
+                .map(String::trim)
+                .filter(s -> !s.isEmpty())
+                .collect(Collectors.toList());
+    }
+
+    static boolean isUrlAllowed(final String url, final List<String> allowedUrls) {
+        if (null == url) {
+            return false;
+        }
+
+        String candidate = url.trim();
+        return allowedUrls.stream().anyMatch(candidate::equals);
+    }
+
+    private static boolean isUrlAllowed(final String url, final AstAdminSettings settings) {
+        return isUrlAllowed(url, parseAllowedUrls(settings));
     }
 
     /**
@@ -396,7 +448,7 @@ public class AstSettingsService {
             results.setResult(res.getState().equals(ERROR) ? FAILURE : SUCCESS);
         } catch (GenericException e) {
             log.warn(e.getDetailedMessage(), e);
-            results.add(e);
+            addConnectionCheckError(results, e);
         }
     }
 
@@ -444,7 +496,39 @@ public class AstSettingsService {
             new Factory().reportsTasks(client).check(reports);
         } catch (GenericException e) {
             log.warn(e.getDetailedMessage(), e);
-            results.add(e);
+            addConnectionCheckError(results, e);
         }
+    }
+
+    static void addConnectionCheckError(@NonNull final VerificationResults results, @NonNull final GenericException e) {
+        if (null != e.getCode()) {
+            results.add(e);
+            return;
+        }
+
+        Throwable root = rootCause(e);
+        if (isSimpleConnectivityError(root)) {
+            String reason = StringUtils.isNotEmpty(root.getMessage()) ? root.getMessage() : root.getClass().getSimpleName();
+            results.add(e.getMessage() + ": " + reason);
+            results.failure();
+            return;
+        }
+
+        results.add(MESSAGE_CONNECTION_CHECK_FAILED);
+        results.failure();
+    }
+
+    private static Throwable rootCause(@NonNull final Throwable e) {
+        Throwable cause = e;
+        while (null != cause.getCause() && cause.getCause() != cause) {
+            cause = cause.getCause();
+        }
+
+        return cause;
+    }
+
+    private static boolean isSimpleConnectivityError(@NonNull final Throwable t) {
+        return t instanceof UnknownHostException
+                || t instanceof SSLException;
     }
 }

--- a/ptai-teamcity-plugin/ptai-teamcity-plugin-server/src/main/resources/buildServerResources/adminPage.jsp
+++ b/ptai-teamcity-plugin/ptai-teamcity-plugin-server/src/main/resources/buildServerResources/adminPage.jsp
@@ -44,7 +44,7 @@
 
         <table class="runnerFormTable">
             <tr class="groupingTitle">
-                <td colspan="2">PT AI server</td>
+                <td colspan="2">PT AI server connection (verified by "<%=Labels.TEST%>")</td>
             </tr>
 
             <tbody class="ptai-group">
@@ -92,10 +92,31 @@
                     <td>
                         <props:checkboxProperty name="${SERVER_SETTINGS_GLOBAL_INSECURE}"/>
 						<span class="smallNote">${HINT_SERVER_SETTINGS_GLOBAL_INSECURE}</span>
+                        <span class="smallNote"><strong>${HINT_SERVER_SETTINGS_GLOBAL_INSECURE_SCOPE}</strong></span>
                         <span class="error" id="error_${SERVER_SETTINGS_GLOBAL_INSECURE}"></span>
                     </td>
                 </tr>
-			
+            </tbody>
+
+            <tr class="groupingTitle">
+                <td colspan="2">Allowed addresses for task-scope build steps</td>
+            </tr>
+
+            <tbody class="ptai-group">
+                <tr>
+                    <th>
+                        <label for="${ALLOWED_URLS}">${LABEL_ALLOWED_URLS}</label>
+                    </th>
+                    <td>
+                        <props:multilineProperty
+                                name="${ALLOWED_URLS}"
+                                className="longField"
+                                linkTitle="Edit allowed PT AI server addresses"
+                                rows="3" cols="49" expanded="${true}"
+                                note="${HINT_ALLOWED_URLS}"/>
+                        <span class="error" id="error_${ALLOWED_URLS}"></span>
+                    </td>
+                </tr>
             </tbody>
         </table>
 

--- a/ptai-teamcity-plugin/ptai-teamcity-plugin-server/src/main/resources/buildServerResources/constants.jsp
+++ b/ptai-teamcity-plugin/ptai-teamcity-plugin-server/src/main/resources/buildServerResources/constants.jsp
@@ -15,6 +15,12 @@
 <c:set var="SERVER_SETTINGS_GLOBAL_INSECURE" value="<%=Params.INSECURE%>"/>
 <c:set var="LABEL_SERVER_SETTINGS_GLOBAL_INSECURE" value="<%=Labels.INSECURE%>"/>
 <c:set var="HINT_SERVER_SETTINGS_GLOBAL_INSECURE" value="<%=Hints.INSECURE%>"/>
+<c:set var="HINT_SERVER_SETTINGS_GLOBAL_INSECURE_SCOPE" value="<%=Hints.INSECURE_SCOPE%>"/>
+
+<c:set var="ALLOWED_URLS" value="<%=Constants.ALLOWED_URLS%>"/>
+<c:set var="LABEL_ALLOWED_URLS" value="<%=Labels.ALLOWED_URLS%>"/>
+<c:set var="LABEL_ALLOWED_URLS_SELECT" value="<%=Labels.ALLOWED_URLS_SELECT%>"/>
+<c:set var="HINT_ALLOWED_URLS" value="<%=Hints.ALLOWED_URLS%>"/>
 
 <c:set var="SERVER_SETTINGS" value="<%=Params.SERVER_SETTINGS%>"/>
 <c:set var="LABEL_SERVER_SETTINGS" value="<%=Labels.SERVER_SETTINGS%>"/>
@@ -29,7 +35,6 @@
 
 <c:set var="SERVER_SETTINGS_LOCAL_URL" value="<%=Params.URL%>"/>
 <c:set var="LABEL_SERVER_SETTINGS_LOCAL_URL" value="<%=Labels.URL%>"/>
-<c:set var="HINT_SERVER_SETTINGS_LOCAL_URL" value="<%=Hints.URL%>"/>
 
 <c:set var="SERVER_SETTINGS_LOCAL_TOKEN" value="<%=Params.TOKEN%>"/>
 <c:set var="LABEL_SERVER_SETTINGS_LOCAL_TOKEN" value="<%=Labels.TOKEN%>"/>

--- a/ptai-teamcity-plugin/ptai-teamcity-plugin-server/src/main/resources/buildServerResources/editRunParams.jsp
+++ b/ptai-teamcity-plugin/ptai-teamcity-plugin-server/src/main/resources/buildServerResources/editRunParams.jsp
@@ -41,7 +41,7 @@
             'row_${SERVER_SETTINGS_LOCAL_URL}',
             'row_${SERVER_SETTINGS_LOCAL_TOKEN}',
             'row_${SERVER_SETTINGS_LOCAL_CERTIFICATES}',
-            'row_${SERVER_SETTINGS_LOCAL_INSECURE}' ];
+            'row_ptaiLocalInsecureNote' ];
 
         // ... converts array to varargs
         ptaiServerSettingsChange = function () {
@@ -228,8 +228,14 @@
             <label for="${SERVER_SETTINGS_LOCAL_URL}">${LABEL_SERVER_SETTINGS_LOCAL_URL}<l:star/></label>
         </th>
         <td>
-            <props:textProperty name="${SERVER_SETTINGS_LOCAL_URL}" className="longField"/>
-            <span class="smallNote">${HINT_SERVER_SETTINGS_LOCAL_URL}</span>
+            <props:selectProperty name="${SERVER_SETTINGS_LOCAL_URL}" enableFilter="true" className="longField">
+                <props:option value=""
+                              currValue="${propertiesBean.properties[SERVER_SETTINGS_LOCAL_URL]}">${LABEL_ALLOWED_URLS_SELECT}</props:option>
+                <c:forEach var="ptaiAllowedUrl" items="${ptaiAllowedUrlList}">
+                    <props:option value="${ptaiAllowedUrl}"
+                                  currValue="${propertiesBean.properties[SERVER_SETTINGS_LOCAL_URL]}">${ptaiAllowedUrl}</props:option>
+                </c:forEach>
+            </props:selectProperty>
             <span class="error" id="error_${SERVER_SETTINGS_LOCAL_URL}"></span>
         </td>
     </tr>
@@ -258,17 +264,6 @@
                     rows="3" cols="49" expanded="${true}"
                     note="${HINT_SERVER_SETTINGS_LOCAL_CERTIFICATES}"/>
             <span class="error" id="error_${SERVER_SETTINGS_LOCAL_CERTIFICATES}"></span>
-        </td>
-    </tr>
-
-    <tr id="row_${SERVER_SETTINGS_LOCAL_INSECURE}">
-        <th>
-            <label for="${SERVER_SETTINGS_LOCAL_INSECURE}">${LABEL_SERVER_SETTINGS_LOCAL_INSECURE}</label>
-        </th>
-        <td>
-            <props:checkboxProperty name="${SERVER_SETTINGS_LOCAL_INSECURE}"/>
-            <span class="smallNote">${HINT_SERVER_SETTINGS_LOCAL_INSECURE}</span>
-            <span class="error" id="error_${SERVER_SETTINGS_LOCAL_INSECURE}"></span>
         </td>
     </tr>
     </tbody>


### PR DESCRIPTION
Изменена страница с админскими настройками  
<img width="977" height="843" alt="image" src="https://github.com/user-attachments/assets/49f01283-a6d9-4341-b2b5-01f04d7c879f" />  

1. `Allowed PT AI server addresses` - cписок адресов, которые доступны для выбора в настройках конкретной сборки. URL из глобальных настроек (поле `PT AI server URL`) в этот список не попадает.
2. Настройка`Accept non-trusted SSL certificates` относится как к глобальным настройкам подключения, так и к task-scope.  

В task-scope настройках `PT AI server URL` - выпадающий список
<img width="937" height="373" alt="image" src="https://github.com/user-attachments/assets/8f1d3171-8d89-47ff-927a-529ed59f5116" />  
<img width="937" height="373" alt="image" src="https://github.com/user-attachments/assets/f4515488-fd6f-4ed4-a000-68ed97f5d23c" />  
<img width="937" height="373" alt="image" src="https://github.com/user-attachments/assets/c1b30e73-a984-44a0-82d8-78be085655ea" />  

Если ни чего не выбрать и попытаться сохранить настройки - будет ошибка
<img width="937" height="65" alt="image" src="https://github.com/user-attachments/assets/f7d6fc59-13e0-482b-9a8d-b7ffd0b13ee6" />  

Также теперь большинство ошибок, кроме парсинга настроек и UnknownHostException и SSLException пишутся обобщенно: `PT AI server connection check failed. Please contact your administrator or check the TeamCity server logs for details`

